### PR TITLE
Link to the ITP webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,8 +101,8 @@
           <p class="animate__animated animate__fadeInUp">
             Co-located with FroCoS and TABLEAUX
           </p>
-          <a href="https://icetcs.github.io/frocos-itp-tableaux25/" class="btn-get-started animate__animated animate__fadeInUp">
-            ITP / FroCoS / TABLEAUX 2025 Website
+          <a href="https://icetcs.github.io/frocos-itp-tableaux25/itp" class="btn-get-started animate__animated animate__fadeInUp">
+            ITP 2025 Website
           </a>
         </div>
       </div>
@@ -137,8 +137,8 @@
               </p>
               <div class="read-more">
                 <p>
-                  <a href="https://icetcs.github.io/frocos-itp-tableaux25/">
-                    <button type="button" class="btn">ITP / FroCoS / TABLEAUX 2025 Website</button>
+                  <a href="https://icetcs.github.io/frocos-itp-tableaux25/itp">
+                    <button type="button" class="btn">ITP 2025 Website</button>
                   </a>
                 </p>
 


### PR DESCRIPTION
Instead of giving a link to the FroCos / ITP / TABLEAUX website (where the link to the ITP page is not easy to find), provide a direct link to the ITP page.